### PR TITLE
Update and change addon icon installation

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": true
+}

--- a/modules/xcb-imdkit.yaml
+++ b/modules/xcb-imdkit.yaml
@@ -4,6 +4,10 @@ sources:
   - type: git
     url: https://github.com/fcitx/xcb-imdkit
     tag: 1.0.2
+    x-checker-data:
+      type: git
+      tag-pattern: "^([\\d.]+)$"
+
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -113,3 +113,9 @@ modules:
         for icon in $(cat icon.txt); do 
           install -Dvm644 -t "/app/$(echo ${icon}|cut -d / -f 5-|xargs dirname)" "$icon"
         done
+        
+  - name: script
+    buildsystem: simple
+    build-commands:
+      - sed -iE 's:(/provides>):\1\n  <content_rating type="oars-1.1" />:g' /app/share/metainfo/org.fcitx.Fcitx5.metainfo.xml
+      - mv /app/share/applications/{fcitx5-configtool,org.fcitx.Fcitx5.configtool}.desktop

--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -117,5 +117,5 @@ modules:
   - name: script
     buildsystem: simple
     build-commands:
-      - sed -iE 's:(/provides>):\1\n  <content_rating type="oars-1.1" />:g' /app/share/metainfo/org.fcitx.Fcitx5.metainfo.xml
+      - sed -E -i 's:(/provides>):\1\n  <content_rating type="oars-1.1" />:g' /app/share/metainfo/org.fcitx.Fcitx5.metainfo.xml
       - mv /app/share/applications/{fcitx5-configtool,org.fcitx.Fcitx5.configtool}.desktop

--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -28,6 +28,20 @@ add-extensions:
     add-ld-path: lib
     autodelete: true
 
+add-build-extensions:
+  org.fcitx.Fcitx5.Addon.ChineseAddons:
+    directory: addons-build/ChineseAddons
+    version: stable
+    remove-after-build: true
+  org.fcitx.Fcitx5.Addon.Mozc:
+    directory: addons-build/Mozc
+    version: stable
+    remove-after-build: true
+  org.fcitx.Fcitx5.Addon.Zhuyin:
+    directory: addons-build/Zhuyin
+    version: stable
+    remove-after-build: true
+
 modules:
   - modules/fmt.yaml
   - modules/xcb-imdkit.yaml
@@ -81,3 +95,12 @@ modules:
       - type: git
         url: https://github.com/fcitx/fcitx5-configtool
         tag: 5.0.8
+
+  - name: addon-icons
+    buildsystem: simple
+    build-commands:
+      - find /app/addons-build/*/share/icons -name "org.fcitx.Fcitx5*" > icon.txt
+      - |
+        for icon in $(cat icon.txt); do 
+          install -Dvm644 -t "/app/$(echo ${icon}|cut -d / -f 5-|xargs dirname)" "$icon"
+        done

--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -1,18 +1,10 @@
 app-id: org.fcitx.Fcitx5
 branch: stable
 base: io.qt.qtwebkit.BaseApp
-base-version: '5.15'
+base-version: '5.15-21.08'
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
-add-extensions:
-  org.fcitx.Fcitx5.Addon:
-    version: stable
-    directory: addons
-    subdirectories: true
-    no-autodownload: true
-    add-ld-path: lib
-    autodelete: true
 separate-locales: false
 command: fcitx5
 finish-args:
@@ -26,6 +18,16 @@ finish-args:
   - --filesystem=xdg-config/fcitx:create
   - --filesystem=xdg-config/ibus:create
   - --device=dri
+
+add-extensions:
+  org.fcitx.Fcitx5.Addon:
+    version: stable
+    directory: addons
+    subdirectories: true
+    no-autodownload: true
+    add-ld-path: lib
+    autodelete: true
+
 modules:
   - modules/fmt.yaml
   - modules/xcb-imdkit.yaml
@@ -37,6 +39,7 @@ modules:
       - type: git
         url: https://github.com/fujiwarat/cldr-emoji-annotation/
         branch: 37.0_13.0_0_2
+
   - name: fcitx5
     buildsystem: cmake-ninja
     config-opts:
@@ -46,17 +49,21 @@ modules:
     sources:
       - type: git
         url: https://github.com/fcitx/fcitx5
-        commit: 01f22b01a6484899786c140177d9cab461cc3139
+        tag: 5.0.10
+
       - type: file
+        dest: src/modules/spell/dict
         url: https://download.fcitx-im.org/data/en_dict-20121020.tar.gz
         sha256: c44a5d7847925eea9e4d2d04748d442cd28dd9299a0b572ef7d91eac4f5a6ceb
-        dest-filename: src/modules/spell/dict/en_dict-20121020.tar.gz
+
       - type: file
         path: fcitx5.sh
+
     post-install:
       - install -d /app/addons
       - mv /app/bin/fcitx5{,-bin}
       - install -m755 fcitx5.sh /app/bin/fcitx5
+
   - name: fcitx5-qt
     buildsystem: cmake-ninja
     config-opts:
@@ -65,72 +72,12 @@ modules:
     sources:
       - type: git
         url: https://github.com/fcitx/fcitx5-qt
-        tag: 5.0.2
+        tag: 5.0.7
+
   - name: fcitx5-configtool
     buildsystem: cmake-ninja
     builddir: true
     sources:
       - type: git
         url: https://github.com/fcitx/fcitx5-configtool
-        tag: 5.0.2
-
-  - name: fcitx5-all-icons
-    buildsystem: simple
-    sources:
-      - type: git
-        url: https://github.com/fcitx/fcitx5-anthy
-        dest: fcitx5-anthy
-        tag: 5.0.2
-      - type: git
-        url: https://github.com/fcitx/fcitx5-chewing
-        dest: fcitx5-chewing
-        tag: 5.0.3
-      - type: git
-        url: https://github.com/fcitx/fcitx5-chinese-addons
-        dest: fcitx5-chinese-addons
-        tag: 5.0.3
-      - type: git
-        url: https://github.com/fcitx/fcitx5-hangul
-        dest: fcitx5-hangul
-        tag: 5.0.2
-      - type: git
-        url: https://github.com/fcitx/fcitx5-kkc
-        dest: fcitx5-kkc
-        tag: 5.0.3
-      - type: git
-        url: https://github.com/fcitx/fcitx5-rime
-        dest: fcitx5-rime
-        tag: 5.0.3
-      - type: git
-        url: https://github.com/fcitx/fcitx5-sayura
-        dest: fcitx5-sayura
-        tag: 5.0.2
-      - type: git
-        url: https://github.com/fcitx/fcitx5-skk
-        dest: fcitx5-skk
-        tag: 5.0.3
-      - type: git
-        url: https://github.com/fcitx/fcitx5-table-extra
-        dest: fcitx5-table-extra
-        tag: 5.0.2
-      - type: git
-        url: https://github.com/fcitx/fcitx5-table-other
-        dest: fcitx5-table-other
-        tag: 5.0.2
-      - type: git
-        url: https://github.com/fcitx/fcitx5-unikey
-        dest: fcitx5-unikey
-        tag: 5.0.2
-      - type: git
-        url: https://github.com/fcitx/fcitx5-zhuyin
-        dest: fcitx5-zhuyin
-        tag: 5.0.2
-      - type: archive
-        url: https://github.com/fcitx/mozc/archive/999aa3e752bc0c9be0b20e5ed11617ee63747062.tar.gz
-        sha256: 'd02af6556fe9ccf29b7708be09acac6f3ade14e85de18a35ff6b4688d917c24c'
-        dest: mozc
-      - type: file
-        path: install_icons
-    build-commands:
-      - ./install_icons
-      - cd mozc/src && PREFIX=${FLATPAK_DEST} ../scripts/install_fcitx5_icons
+        tag: 5.0.8

--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -66,7 +66,7 @@ modules:
         tag: 5.0.10
         x-checker-data:
           type: git
-          tag-pattern: "^v([\\d.]+)$"
+          tag-pattern: "^([\\d.]+)$"
 
       - type: file
         dest: src/modules/spell/dict
@@ -92,7 +92,7 @@ modules:
         tag: 5.0.7
         x-checker-data:
           type: git
-          tag-pattern: "^v([\\d.]+)$"
+          tag-pattern: "^([\\d.]+)$"
 
   - name: fcitx5-configtool
     buildsystem: cmake-ninja
@@ -103,7 +103,7 @@ modules:
         tag: 5.0.8
         x-checker-data:
           type: git
-          tag-pattern: "^v([\\d.]+)$"
+          tag-pattern: "^([\\d.]+)$"
 
   - name: addon-icons
     buildsystem: simple

--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -64,6 +64,9 @@ modules:
       - type: git
         url: https://github.com/fcitx/fcitx5
         tag: 5.0.10
+        x-checker-data:
+          type: git
+          tag-pattern: "^v([\\d.]+)$"
 
       - type: file
         dest: src/modules/spell/dict
@@ -87,6 +90,9 @@ modules:
       - type: git
         url: https://github.com/fcitx/fcitx5-qt
         tag: 5.0.7
+        x-checker-data:
+          type: git
+          tag-pattern: "^v([\\d.]+)$"
 
   - name: fcitx5-configtool
     buildsystem: cmake-ninja
@@ -95,6 +101,9 @@ modules:
       - type: git
         url: https://github.com/fcitx/fcitx5-configtool
         tag: 5.0.8
+        x-checker-data:
+          type: git
+          tag-pattern: "^v([\\d.]+)$"
 
   - name: addon-icons
     buildsystem: simple


### PR DESCRIPTION
Use `add-build-extensions` to install addon icon  
The addon will be loaded into `/app/addons-build` during build, and keep empty folder after build  

Add `x-checker-data` to auto update  