### PR TITLE
Run cleanup-BaseApp.sh to reduce the Flatpak size

### DIFF
--- a/org.fcitx.Fcitx5.yaml
+++ b/org.fcitx.Fcitx5.yaml
@@ -30,6 +30,8 @@ finish-args:
   - --filesystem=xdg-config/ibus:create
   - --filesystem=xdg-cache/ibus:create
   - --device=dri
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
 modules:
   - modules/xcb-imdkit.yaml
   - modules/libuv.yaml


### PR DESCRIPTION
Run cleanup-BaseApp.sh to reduce the Flatpak size

See: https://github.com/flathub/io.qt.qtwebengine.BaseApp#cleanup

**I'm not sure about extensions. Please don't forget to test before merging.**